### PR TITLE
Fixed language being set based off id instead of name

### DIFF
--- a/src/api/handlers/appointments/postAppointments.js
+++ b/src/api/handlers/appointments/postAppointments.js
@@ -46,7 +46,7 @@ export default async (req, res) => {
   const message = {
     appointmentId: insertedAppointmentId,
     messageBody,
-    language: language.id,
+    language: language.name,
     templateName: template.templateName,
     // UTC
     timeSent: moment().format("YYYY-MM-DD HH:mm:ss")


### PR DESCRIPTION
Languages in the DB are implemented as ENUMs which do have an internal index based on their insertion order. This is a separate number from the hardcoded language IDs in the constant file. This causes the insert to select the wrong language when the insertion is done by id.

The ENUM approach will be hard to maintain in the long run as each table will need to be updated separately any time there is a change to the allowed languages. 

Closes #38 