### PR TITLE
Add country code to phone number before sending it to Twilio

### DIFF
--- a/src/services/twilioClient.js
+++ b/src/services/twilioClient.js
@@ -1,20 +1,33 @@
-'use strict';
-
 import { twilioConfig } from "../config";
 
-const client = require('twilio')(twilioConfig.accountSid, twilioConfig.authToken);
-const MessagingResponse = require('twilio').twiml.MessagingResponse;
+const client = require("twilio")(
+  twilioConfig.accountSid,
+  twilioConfig.authToken
+);
+const MessagingResponse = require("twilio").twiml.MessagingResponse;
+const countryCode = "+1";
 
 export const sendMessage = (phoneNumber, message) => {
-  return client.messages
-    .create({
-      body: message,
-      from: twilioConfig.number,
-      to: phoneNumber
-    });
+  if (phoneNumber.length !== 10) {
+    throw Error("Phone number must be 10 digits long.");
+  }
+
+  if (!/^\d+$/.test(phoneNumber)) {
+    throw Error("Phone number must only contain digits.");
+  }
+
+  console.log(phoneNumber);
+
+  return client.messages.create({
+    body: message,
+    from: twilioConfig.number,
+    to: `${countryCode}${phoneNumber}`,
+  });
 };
 
-export const getMessageResponse = (message = "Thank you for your confirmation!") => {
+export const getMessageResponse = (
+  message = "Thank you for your confirmation!"
+) => {
   const twiml = new MessagingResponse();
   twiml.message(message);
 


### PR DESCRIPTION
This adds a hard coded +1 country code to all phone numbers before sending it to Twilio. All phone number should already be a 10 digit number based on validation added in previous PRs but that is double checked here.

Closes #37 