### PR TITLE
Fixed existing generateMessage test and added more

### DIFF
--- a/src/models/templates.js
+++ b/src/models/templates.js
@@ -15,6 +15,7 @@ Special Notes: {{specialNotes}}
 
 If you have any questions, please call Sanctuary Refugee Health Centre (Dr. Michael Stephenson) at 226-336-1321.`,
 
+    // \u200E is the left-to-right mark and is used to improve mixing LTR text into the RTL message
     Arabic: `هذه رسالة من عيادة الدكتور مايكل طبيب العائلة إلى \u200E({{patientName}}). هناك موعد \u200E({{practitionerAddress}}) يوم \u200E({{appointmentDateTime}}) على العنوان التالي: (العنوان)
     للاستفسار رجاءًا الاتصال على الرقم التالي:`,
 

--- a/src/models/templates.js
+++ b/src/models/templates.js
@@ -13,10 +13,9 @@ Address: {{practitionerAddress}}
 Special Notes: {{specialNotes}}
 {{/specialNotes}}
 
-If you have any questions, please call Sanctuary Refugee Health Centre (Dr. Michael Stephenson) at 226-336-1321.
-    `,
+If you have any questions, please call Sanctuary Refugee Health Centre (Dr. Michael Stephenson) at 226-336-1321.`,
 
-    Arabic: `هذه رسالة من عيادة الدكتور مايكل طبيب العائلة إلى ( {{patientName}}). هناك موعد ({{practitionerAddress}}) يوم ({{appointmentDateTime}}) على العنوان التالي: (العنوان)
+    Arabic: `هذه رسالة من عيادة الدكتور مايكل طبيب العائلة إلى \u200E({{patientName}}). هناك موعد \u200E({{practitionerAddress}}) يوم \u200E({{appointmentDateTime}}) على العنوان التالي: (العنوان)
     للاستفسار رجاءًا الاتصال على الرقم التالي:`,
 
     Amharic: `ይህከዶ / ር ሚካኤል እስጢፋኖስ ቢሮ - ቅዱስ ሥደተኞች የጤና ማእከል ለ {{patientName}} መልእክት ነው ፡፡ በሚተቀለው አድራሻ {{practitionerAddress}} ላይ {{appointmentDateTime}} ቀጠሮ አልዎት ፡፡
@@ -28,7 +27,7 @@ If you have any questions, please call Sanctuary Refugee Health Centre (Dr. Mich
     Turkish: `Sayin {{patientName}},  {{appointmentDateTime}} tarihinde  {{practitionerAddress}} adresinde bulunan (Consult/ Imaging) ile randevunuz vardir. Sorulariniz icin bizi 226-336-1321'den arayabilirsiniz.
     Dr Michael Stephensoniun - Sanctuary Refugee Health Centre`,
 
-    Spanish: `Este es un mensaje de la oficina del Dr. Michel Stephenson - Sanctuary Refugee Health Centre para: {{patientName}}. Usted tiene una cita con (Consult)/(Imaging)el {{appointmentDateTime}}en la siguiente dirección: {{practitionerAddress}}. 
+    Spanish: `Este es un mensaje de la oficina del Dr. Michel Stephenson - Sanctuary Refugee Health Centre para: {{patientName}}. Usted tiene una cita con (Consult)/(Imaging)el {{appointmentDateTime}} en la siguiente dirección: {{practitionerAddress}}. 
     Si usted tiene alguna pregunta, por favor llamenos al 226-336-1321.`,
   },
   {

--- a/src/models/templates.test.js
+++ b/src/models/templates.test.js
@@ -6,15 +6,164 @@ describe("#generateMessage()", function () {
   it("should return formatted message in English", function () {
     const metadata = {
       patientName: "John Smith",
-      appointmentTime: moment("2020-01-02T03:04").format("YYYY-MM-DD h:mm a"),
+      appointmentDate: moment("2020-01-02T03:04").format("YYYY-MM-DD"),
+      appointmentTime: moment("2020-01-02T03:04").format("h:mm a"),
       practitionerAddress: "123 Fake St.",
     };
 
     const actual = TemplatesModel.generateMessage(1, "English", metadata);
 
-    const expected = `This is a message from Dr. Michael Stephenson's office - Sanctuary Refugee Health Centre to John Smith.
-You have an appointment for (Consult/ Imaging) on 2020-01-02 3:04 am at the the following address 123 Fake St..
-If have any questions, please call us at 226-336-1321.`;
+    const expected = `Dear John Smith, this message is to inform you of your upcoming appointment.
+
+Date: 2020-01-02
+Time: 3:04 am
+Address: 123 Fake St.
+
+If you have any questions, please call Sanctuary Refugee Health Centre (Dr. Michael Stephenson) at 226-336-1321.`;
+
+    expect(actual).to.equal(expected);
+  });
+
+  it("should return formatted message in English with description", function () {
+    const metadata = {
+      patientName: "John Smith",
+      appointmentDate: moment("2020-01-02T03:04").format("YYYY-MM-DD"),
+      appointmentTime: moment("2020-01-02T03:04").format("h:mm a"),
+      practitionerAddress: "123 Fake St.",
+      description: "X-ray",
+    };
+
+    const actual = TemplatesModel.generateMessage(1, "English", metadata);
+
+    const expected = `Dear John Smith, this message is to inform you of your upcoming appointment: X-ray.
+
+Date: 2020-01-02
+Time: 3:04 am
+Address: 123 Fake St.
+
+If you have any questions, please call Sanctuary Refugee Health Centre (Dr. Michael Stephenson) at 226-336-1321.`;
+
+    expect(actual).to.equal(expected);
+  });
+
+  it("should return formatted message in English with special notes", function () {
+    const metadata = {
+      patientName: "John Smith",
+      appointmentDate: moment("2020-01-02T03:04").format("YYYY-MM-DD"),
+      appointmentTime: moment("2020-01-02T03:04").format("h:mm a"),
+      practitionerAddress: "123 Fake St.",
+      specialNotes: "This is a special note",
+    };
+
+    const actual = TemplatesModel.generateMessage(1, "English", metadata);
+
+    const expected = `Dear John Smith, this message is to inform you of your upcoming appointment.
+
+Date: 2020-01-02
+Time: 3:04 am
+Address: 123 Fake St.
+Special Notes: This is a special note
+
+If you have any questions, please call Sanctuary Refugee Health Centre (Dr. Michael Stephenson) at 226-336-1321.`;
+
+    expect(actual).to.equal(expected);
+  });
+
+  it("should return formatted message in English with description and special notes", function () {
+    const metadata = {
+      patientName: "John Smith",
+      appointmentDate: moment("2020-01-02T03:04").format("YYYY-MM-DD"),
+      appointmentTime: moment("2020-01-02T03:04").format("h:mm a"),
+      practitionerAddress: "123 Fake St.",
+      description: "X-ray",
+      specialNotes: "This is a special note",
+    };
+
+    const actual = TemplatesModel.generateMessage(1, "English", metadata);
+
+    const expected = `Dear John Smith, this message is to inform you of your upcoming appointment: X-ray.
+
+Date: 2020-01-02
+Time: 3:04 am
+Address: 123 Fake St.
+Special Notes: This is a special note
+
+If you have any questions, please call Sanctuary Refugee Health Centre (Dr. Michael Stephenson) at 226-336-1321.`;
+
+    expect(actual).to.equal(expected);
+  });
+
+  it("should return formatted message in Arabic", function () {
+    const metadata = {
+      patientName: "John Smith",
+      appointmentDateTime: moment("2020-01-02T03:04").format("YYYY-MM-DD h:mm a"),
+      practitionerAddress: "123 Fake St.",
+    };
+
+    const actual = TemplatesModel.generateMessage(1, "Arabic", metadata);
+    
+    const expected = `هذه رسالة من عيادة الدكتور مايكل طبيب العائلة إلى ‎(John Smith). هناك موعد ‎(123 Fake St.) يوم ‎(2020-01-02 3:04 am) على العنوان التالي: (العنوان)
+    للاستفسار رجاءًا الاتصال على الرقم التالي:`;
+
+    expect(actual).to.equal(expected);
+  });
+
+  it("should return formatted message in Amharic", function () {
+    const metadata = {
+      patientName: "John Smith",
+      appointmentDateTime: moment("2020-01-02T03:04").format("YYYY-MM-DD h:mm a"),
+      practitionerAddress: "123 Fake St.",
+    };
+
+    const actual = TemplatesModel.generateMessage(1, "Amharic", metadata);
+
+    const expected = `ይህከዶ / ር ሚካኤል እስጢፋኖስ ቢሮ - ቅዱስ ሥደተኞች የጤና ማእከል ለ John Smith መልእክት ነው ፡፡ በሚተቀለው አድራሻ 123 Fake St. ላይ 2020-01-02 3:04 am ቀጠሮ አልዎት ፡፡
+    ማናቸውምጥያቄዎች ካሉዎት እባክዎን በ 226-336-1321 ይደውሉልን ፡`;
+
+    expect(actual).to.equal(expected);
+  });
+
+  it("should return formatted message in Somali", function () {
+    const metadata = {
+      patientName: "John Smith",
+      appointmentDateTime: moment("2020-01-02T03:04").format("YYYY-MM-DD h:mm a"),
+      practitionerAddress: "123 Fake St.",
+    };
+
+    const actual = TemplatesModel.generateMessage(1, "Somali", metadata);
+
+    const expected = `Tani waa dhambaal ka socda xafiiska Dr.Michael Steaphenson ee Sanctuary (John Smith). Ballan ayaad u leedahay (La-tashi / Sawir Raajo or Computer) maalinta {Taariikhda} (123 Fake St.)cinwaanka soo socda.
+    Haddii aad qabtid wax su'aalo ah, fadlan naga soo wac Numbarkan.226-336-1321.`;
+
+    expect(actual).to.equal(expected);
+  });
+
+  it("should return formatted message in Turkish", function () {
+    const metadata = {
+      patientName: "John Smith",
+      appointmentDateTime: moment("2020-01-02T03:04").format("YYYY-MM-DD h:mm a"),
+      practitionerAddress: "123 Fake St.",
+    };
+
+    const actual = TemplatesModel.generateMessage(1, "Turkish", metadata);
+
+    const expected = `Sayin John Smith,  2020-01-02 3:04 am tarihinde  123 Fake St. adresinde bulunan (Consult/ Imaging) ile randevunuz vardir. Sorulariniz icin bizi 226-336-1321'den arayabilirsiniz.
+    Dr Michael Stephensoniun - Sanctuary Refugee Health Centre`;
+
+    expect(actual).to.equal(expected);
+  });
+
+  it("should return formatted message in Spanish", function () {
+    const metadata = {
+      patientName: "John Smith",
+      appointmentDateTime: moment("2020-01-02T03:04").format("YYYY-MM-DD h:mm a"),
+      practitionerAddress: "123 Fake St.",
+    };
+
+    const actual = TemplatesModel.generateMessage(1, "Spanish", metadata);
+
+    const expected = `Este es un mensaje de la oficina del Dr. Michel Stephenson - Sanctuary Refugee Health Centre para: John Smith. Usted tiene una cita con (Consult)/(Imaging)el 2020-01-02 3:04 am en la siguiente dirección: 123 Fake St.. 
+    Si usted tiene alguna pregunta, por favor llamenos al 226-336-1321.`;
 
     expect(actual).to.equal(expected);
   });


### PR DESCRIPTION
`\u200E` is the [Unicode left-to-right mark](https://en.wikipedia.org/wiki/Left-to-right_mark) and was an attempt to improve Arabic support. The mix of RTL and LTR text causes issues and is still not correct.

The top is without `\u200E` and the bottom is with. I am not sure why John Smith is the same in both

![Screenshot_20200909-140816](https://user-images.githubusercontent.com/5401207/92637675-26a48d80-f2a7-11ea-94ea-eb90278eba08.png)

I have created a separate ticket for figuring out RTL language support https://github.com/SanctuaryRefugeeHealth/sanctuary-patient-api/issues/61.

Closes #58 
