### PR TITLE
Switch templates to triple curly brackets to prevent unwanted escaping

### DIFF
--- a/src/models/templates.js
+++ b/src/models/templates.js
@@ -4,58 +4,58 @@ const templates = [
   {
     templateId: 1,
     templateName: "Appointment Reminder",
-    English: `Dear {{patientName}}, this message is to inform you of your upcoming appointment:{{#description}}
-{{description}}{{/description}}
-Date: {{appointmentDate}}
-Time: {{appointmentTime}}
-Address: {{practitionerAddress}}{{#specialNotes}}
-Special Notes: {{specialNotes}}{{/specialNotes}}
+    English: `Dear {{{patientName}}}, this message is to inform you of your upcoming appointment:{{{#description}}}
+{{{description}}}{{{/description}}}
+Date: {{{appointmentDate}}}
+Time: {{{appointmentTime}}}
+Address: {{{practitionerAddress}}}{{{#specialNotes}}}
+Special Notes: {{{specialNotes}}}{{{/specialNotes}}}
 
 Please confirm your attendance by replying “Yes” or “No”.
 If you need an interpreter, please reply with the word "interpreter".
 If you have any questions, please call Sanctuary Refugee Health Centre (Dr. Michael Stephenson) at 226-336-1321.`,
 
     // \u200E is the left-to-right mark and is used to improve mixing LTR text into the RTL message
-    Arabic: `السّيد(ة) \u200E{{patientName}}، هذه رسالة لإعلامك بالموعد:{{#description}}
-\u200E{{description}}{{/description}}
-التّاريخ: \u200E{{appointmentDate}}
-الوقت: \u200E{{appointmentTime}}
-العنوان: \u200E{{practitionerAddress}}{{#specialNotes}}
-تعليمات خاصّة: \u200E{{specialNotes}}{{/specialNotes}}
+    Arabic: `السّيد(ة) \u200E{{{patientName}}}، هذه رسالة لإعلامك بالموعد:{{{#description}}}
+\u200E{{{description}}}{{{/description}}}
+التّاريخ: \u200E{{{appointmentDate}}}
+الوقت: \u200E{{{appointmentTime}}}
+العنوان: \u200E{{{practitionerAddress}}}{{{#specialNotes}}}
+تعليمات خاصّة: \u200E{{{specialNotes}}}{{{/specialNotes}}}
 
 يرجى تأكيد الحضور بالإجابة بـِ "نعم" أو "لا".
 إذا كنتم تحتاجون لمترجم، يرجى الرّد بكلمة "مترجم".
 إذا كانت لديكم أيّة استفسارات، يرجى الاتّصال بعيادة السانكتشوري (الدكتور مايكل ستيفنسن) على الرّقم التّالي: \u200E226-336-1321`,
 
-    Amharic: `ለ {{patientName}}፣ ይህ መልእክት የሚከተለው ቀጠሮ እንዳለዎት ለማሳወቅ ነው፥:{{#description}}
-{{description}}{{/description}}
-ቀን፦ {{appointmentDate}}
-ሰዐት፦ {{appointmentTime}}
-አድራሻ፦ {{practitionerAddress}}{{#specialNotes}}
-ማስታወሻ፦ {{specialNotes}}{{/specialNotes}}
+    Amharic: `ለ {{{patientName}}}፣ ይህ መልእክት የሚከተለው ቀጠሮ እንዳለዎት ለማሳወቅ ነው፥:{{{#description}}}
+{{{description}}}{{{/description}}}
+ቀን፦ {{{appointmentDate}}}
+ሰዐት፦ {{{appointmentTime}}}
+አድራሻ፦ {{{practitionerAddress}}}{{{#specialNotes}}}
+ማስታወሻ፦ {{{specialNotes}}}{{{/specialNotes}}}
 
 በዚህ ቀጠሮ ላይ እገኛለሁ ወይም አልገኝም በማለት እንዲያሳውቁን በትህትና እንጠይቃለን።
 አስተርጓሚ ካስፈለግዎ፣ እባኮ "አስተርጓሚ" በማለት ይመልሱ።
 ጥያቄ ካለዎት፣እባኮ በ 226-336-1321 Sanctuary Refugee Health Centre በመደወል (ዶ/ር ማይክል
 ስቴፈንሰን) ያነጋግሩ። `,
 
-    Somali: `Gacaliye {{patientName}}, Farriintan ayaa ah in lagu ogeysiiyo ballantaada soo socota:{{#description}}
-{{description}}{{/description}}
-Taariikh: {{appointmentDate}}
-Waqtiga: {{appointmentTime}}
-Cinwaanka: {{practitionerAddress}}{{#specialNotes}}
-Ogeysiis gaar ah: {{specialNotes}}{{/specialNotes}}
+    Somali: `Gacaliye {{{patientName}}}, Farriintan ayaa ah in lagu ogeysiiyo ballantaada soo socota:{{{#description}}}
+{{{description}}}{{{/description}}}
+Taariikh: {{{appointmentDate}}}
+Waqtiga: {{{appointmentTime}}}
+Cinwaanka: {{{practitionerAddress}}}{{{#specialNotes}}}
+Ogeysiis gaar ah: {{{specialNotes}}}{{{/specialNotes}}}
 
 Fadlan xaqiiji imaanshahaaga adoo ku jawaabaya "Haa" ama "Maya"
 Haddii aad u baahan tahay turjubaan, fadlan ku jawaab ereyga "turjubaan"
 Haddii aad wax su'aalo ah qabtid, fadlan wac Xarunta Caafimaadka Qaxootiga ee Sanctuary (Dr. Michael Stephenson) lambarka 226-336-1321`,
 
-    Turkish: `Sayin {{patientName}}, Bu mesaj randevunuz ile ilgili sizi bilgilendirme amacli gonderilmistir:{{#description}}
-{{description}}{{/description}}
-Tarih: {{appointmentDate}}
-Saat: {{appointmentTime}}
-Adres: {{practitionerAddress}}{{#specialNotes}}
-Ozel notlar: {{specialNotes}}{{/specialNotes}}
+    Turkish: `Sayin {{{patientName}}}, Bu mesaj randevunuz ile ilgili sizi bilgilendirme amacli gonderilmistir:{{{#description}}}
+{{{description}}}{{{/description}}}
+Tarih: {{{appointmentDate}}}
+Saat: {{{appointmentTime}}}
+Adres: {{{practitionerAddress}}}{{{#specialNotes}}}
+Ozel notlar: {{{specialNotes}}}{{{/specialNotes}}}
 
 Lutfen randevunuza katilim durumunuzu, bu mesaji “Evet” ya da “Hayir” seklinde
 yanitlayarak bildiriniz
@@ -63,23 +63,23 @@ Eger tercumana ihtiyaciniz varsa lutfen bu mesaji "tercuman" yazarak yanitlayini
 Sorulariniz icin lutfen bizi 226-336-1321 numarali telefondan arayiniz.
 Sanctuary Refugee Health Centre - Dr Michael Stephenson`,
 
-    Spanish: `Estimado(a) {{patientName}}, Este mensaje es para informarle que usted tiene una próxima cita:{{#description}}
-{{description}}{{/description}}
-Fecha: {{appointmentDate}}
-Hora: {{appointmentTime}}
-Direccion: {{practitionerAddress}}{{#specialNotes}}
-Notas especiales: {{specialNotes}}{{/specialNotes}}
+    Spanish: `Estimado(a) {{{patientName}}}, Este mensaje es para informarle que usted tiene una próxima cita:{{{#description}}}
+{{{description}}}{{{/description}}}
+Fecha: {{{appointmentDate}}}
+Hora: {{{appointmentTime}}}
+Direccion: {{{practitionerAddress}}}{{{#specialNotes}}}
+Notas especiales: {{{specialNotes}}}{{{/specialNotes}}}
 
 Por favor confirme su asistencia respondiendo “Si” o “No”
 Si usted necesita un intérprete, por favor responda con la palabra “intérprete”
 Si usted tiene alguna pregunta, por favor llame a Sanctuary Refugee Health Centre (Dr. Michael Stephenson) al 226-336-1321.`,
 
-    Tigrinya: `ዝኸበርካ/ኪ {{patientName}} እዚ ሓበሬታዚ፡ ናይ ዝመጽእ ቆጸራኻ/ኺ መዘኻኸሪ እዩ :{{#description}}
-{{description}}{{/description}}
-ዕለት {{appointmentDate}}
-ሰዓት {{appointmentTime}}
-ኣድራሻ {{practitionerAddress}}{{#specialNotes}}
-ፍሉይ ሓበሬታ {{specialNotes}}{{/specialNotes}}
+    Tigrinya: `ዝኸበርካ/ኪ {{{patientName}}} እዚ ሓበሬታዚ፡ ናይ ዝመጽእ ቆጸራኻ/ኺ መዘኻኸሪ እዩ :{{{#description}}}
+{{{description}}}{{{/description}}}
+ዕለት {{{appointmentDate}}}
+ሰዓት {{{appointmentTime}}}
+ኣድራሻ {{{practitionerAddress}}}{{{#specialNotes}}}
+ፍሉይ ሓበሬታ {{{specialNotes}}}{{{/specialNotes}}}
 
 ኣብ ቆጸራኻ/ኺ ከም እትርከብ/ቢ፡ ሓብሩና “እወ ክርከብ እየ”፤ “ኣይፋለይን”
 ኣተርጓሚ ዘድልየካ/ኪ እንተኾይኑ፡ “ኣተርጓሚ” ( interpreter ) የድልየኒ እዩ ብምባል መልሱልና ።
@@ -121,69 +121,69 @@ Si usted tiene alguna pregunta, por favor llame a Sanctuary Refugee Health Centr
   {
     templateId: 3,
     templateName: "Appointment Reminder Subsequent",
-    English: `Dear {{patientName}}, this message is to inform you of your upcoming appointment:{{#description}}
-{{description}}{{/description}}
-Date: {{appointmentDate}}
-Time: {{appointmentTime}}
-Address: {{practitionerAddress}}{{#specialNotes}}
-Special Notes: {{specialNotes}}{{/specialNotes}}
+    English: `Dear {{{patientName}}}, this message is to inform you of your upcoming appointment:{{{#description}}}
+{{{description}}}{{{/description}}}
+Date: {{{appointmentDate}}}
+Time: {{{appointmentTime}}}
+Address: {{{practitionerAddress}}}{{{#specialNotes}}}
+Special Notes: {{{specialNotes}}}{{{/specialNotes}}}
 
 If you have any questions, please call Sanctuary Refugee Health Centre (Dr. Michael Stephenson) at 226-336-1321.`,
 
     // \u200E is the left-to-right mark and is used to improve mixing LTR text into the RTL message
-    Arabic: `السّيد(ة) \u200E{{patientName}}، هذه رسالة لإعلامك بالموعد:{{#description}}
-\u200E{{description}}{{/description}}
-التّاريخ: \u200E{{appointmentDate}}
-الوقت: \u200E{{appointmentTime}}
-العنوان: \u200E{{practitionerAddress}}{{#specialNotes}}
-تعليمات خاصّة: \u200E{{specialNotes}}{{/specialNotes}}
+    Arabic: `السّيد(ة) \u200E{{{patientName}}}، هذه رسالة لإعلامك بالموعد:{{{#description}}}
+\u200E{{{description}}}{{{/description}}}
+التّاريخ: \u200E{{{appointmentDate}}}
+الوقت: \u200E{{{appointmentTime}}}
+العنوان: \u200E{{{practitionerAddress}}}{{{#specialNotes}}}
+تعليمات خاصّة: \u200E{{{specialNotes}}}{{{/specialNotes}}}
 
 إذا كانت لديكم أيّة استفسارات، يرجى الاتّصال بعيادة السانكتشوري (الدكتور مايكل ستيفنسن) على الرّقم التّالي: \u200E226-336-1321`,
 
-    Amharic: `ለ {{patientName}}፣ ይህ መልእክት የሚከተለው ቀጠሮ እንዳለዎት ለማሳወቅ ነው፥:{{#description}}
-{{description}}{{/description}}
-ቀን፦ {{appointmentDate}}
-ሰዐት፦ {{appointmentTime}}
-አድራሻ፦ {{practitionerAddress}}{{#specialNotes}}
-ማስታወሻ፦ {{specialNotes}}{{/specialNotes}}
+    Amharic: `ለ {{{patientName}}}፣ ይህ መልእክት የሚከተለው ቀጠሮ እንዳለዎት ለማሳወቅ ነው፥:{{{#description}}}
+{{{description}}}{{{/description}}}
+ቀን፦ {{{appointmentDate}}}
+ሰዐት፦ {{{appointmentTime}}}
+አድራሻ፦ {{{practitionerAddress}}}{{{#specialNotes}}}
+ማስታወሻ፦ {{{specialNotes}}}{{{/specialNotes}}}
 
 ጥያቄ ካለዎት፣እባኮ በ 226-336-1321 Sanctuary Refugee Health Centre በመደወል (ዶ/ር ማይክል
 ስቴፈንሰን) ያነጋግሩ። `,
 
-    Somali: `Gacaliye {{patientName}}, Farriintan ayaa ah in lagu ogeysiiyo ballantaada soo socota:{{#description}}
-{{description}}{{/description}}
-Taariikh: {{appointmentDate}}
-Waqtiga: {{appointmentTime}}
-Cinwaanka: {{practitionerAddress}}{{#specialNotes}}
-Ogeysiis gaar ah: {{specialNotes}}{{/specialNotes}}
+    Somali: `Gacaliye {{{patientName}}}, Farriintan ayaa ah in lagu ogeysiiyo ballantaada soo socota:{{{#description}}}
+{{{description}}}{{{/description}}}
+Taariikh: {{{appointmentDate}}}
+Waqtiga: {{{appointmentTime}}}
+Cinwaanka: {{{practitionerAddress}}}{{{#specialNotes}}}
+Ogeysiis gaar ah: {{{specialNotes}}}{{{/specialNotes}}}
 
 Haddii aad wax su'aalo ah qabtid, fadlan wac Xarunta Caafimaadka Qaxootiga ee Sanctuary (Dr. Michael Stephenson) lambarka 226-336-1321`,
 
-    Turkish: `Sayin {{patientName}}, Bu mesaj randevunuz ile ilgili sizi bilgilendirme amacli gonderilmistir:{{#description}}
-{{description}}{{/description}}
-Tarih: {{appointmentDate}}
-Saat: {{appointmentTime}}
-Adres: {{practitionerAddress}}{{#specialNotes}}
-Ozel notlar: {{specialNotes}}{{/specialNotes}}
+    Turkish: `Sayin {{{patientName}}}, Bu mesaj randevunuz ile ilgili sizi bilgilendirme amacli gonderilmistir:{{{#description}}}
+{{{description}}}{{{/description}}}
+Tarih: {{{appointmentDate}}}
+Saat: {{{appointmentTime}}}
+Adres: {{{practitionerAddress}}}{{{#specialNotes}}}
+Ozel notlar: {{{specialNotes}}}{{{/specialNotes}}}
 
 Sorulariniz icin lutfen bizi 226-336-1321 numarali telefondan arayiniz.
 Sanctuary Refugee Health Centre - Dr Michael Stephenson`,
 
-    Spanish: `Estimado(a) {{patientName}}, Este mensaje es para informarle que usted tiene una próxima cita:{{#description}}
-{{description}}{{/description}}
-Fecha: {{appointmentDate}}
-Hora: {{appointmentTime}}
-Direccion: {{practitionerAddress}}{{#specialNotes}}
-Notas especiales: {{specialNotes}}{{/specialNotes}}
+    Spanish: `Estimado(a) {{{patientName}}}, Este mensaje es para informarle que usted tiene una próxima cita:{{{#description}}}
+{{{description}}}{{{/description}}}
+Fecha: {{{appointmentDate}}}
+Hora: {{{appointmentTime}}}
+Direccion: {{{practitionerAddress}}}{{{#specialNotes}}}
+Notas especiales: {{{specialNotes}}}{{{/specialNotes}}}
 
 Si usted tiene alguna pregunta, por favor llame a Sanctuary Refugee Health Centre (Dr. Michael Stephenson) al 226-336-1321.`,
 
-    Tigrinya: `ዝኸበርካ/ኪ {{patientName}} እዚ ሓበሬታዚ፡ ናይ ዝመጽእ ቆጸራኻ/ኺ መዘኻኸሪ እዩ :{{#description}}
-{{description}}{{/description}}
-ዕለት {{appointmentDate}}
-ሰዓት {{appointmentTime}}
-ኣድራሻ {{practitionerAddress}}{{#specialNotes}}
-ፍሉይ ሓበሬታ {{specialNotes}}{{/specialNotes}}
+    Tigrinya: `ዝኸበርካ/ኪ {{{patientName}}} እዚ ሓበሬታዚ፡ ናይ ዝመጽእ ቆጸራኻ/ኺ መዘኻኸሪ እዩ :{{{#description}}}
+{{{description}}}{{{/description}}}
+ዕለት {{{appointmentDate}}}
+ሰዓት {{{appointmentTime}}}
+ኣድራሻ {{{practitionerAddress}}}{{{#specialNotes}}}
+ፍሉይ ሓበሬታ {{{specialNotes}}}{{{/specialNotes}}}
 
 ሕቶ እንተለኩም፡ ወይ ዝያዳ ሓበሬታ እንተደለኹም፡ ንሳንክቿሪ ረፉጂ ሀልዝ ሰንተር (Sanctuary Refugee Health Centre, Dr. Michael Stephenson )፡ ንዶር. ማይክል ስቲፈንሰን ኣብ 226-336-132 ብምድዋል ክትሓቱ ትኽእሉ።`,
   },

--- a/src/models/templates.js
+++ b/src/models/templates.js
@@ -4,58 +4,58 @@ const templates = [
   {
     templateId: 1,
     templateName: "Appointment Reminder",
-    English: `Dear {{{patientName}}}, this message is to inform you of your upcoming appointment:{{{#description}}}
-{{{description}}}{{{/description}}}
+    English: `Dear {{{patientName}}}, this message is to inform you of your upcoming appointment:{{#description}}
+{{{description}}}{{/description}}
 Date: {{{appointmentDate}}}
 Time: {{{appointmentTime}}}
-Address: {{{practitionerAddress}}}{{{#specialNotes}}}
-Special Notes: {{{specialNotes}}}{{{/specialNotes}}}
+Address: {{{practitionerAddress}}}{{#specialNotes}}
+Special Notes: {{{specialNotes}}}{{/specialNotes}}
 
 Please confirm your attendance by replying “Yes” or “No”.
 If you need an interpreter, please reply with the word "interpreter".
 If you have any questions, please call Sanctuary Refugee Health Centre (Dr. Michael Stephenson) at 226-336-1321.`,
 
     // \u200E is the left-to-right mark and is used to improve mixing LTR text into the RTL message
-    Arabic: `السّيد(ة) \u200E{{{patientName}}}، هذه رسالة لإعلامك بالموعد:{{{#description}}}
-\u200E{{{description}}}{{{/description}}}
+    Arabic: `السّيد(ة) \u200E{{{patientName}}}، هذه رسالة لإعلامك بالموعد:{{#description}}
+\u200E{{{description}}}{{/description}}
 التّاريخ: \u200E{{{appointmentDate}}}
 الوقت: \u200E{{{appointmentTime}}}
-العنوان: \u200E{{{practitionerAddress}}}{{{#specialNotes}}}
-تعليمات خاصّة: \u200E{{{specialNotes}}}{{{/specialNotes}}}
+العنوان: \u200E{{{practitionerAddress}}}{{#specialNotes}}
+تعليمات خاصّة: \u200E{{{specialNotes}}}{{/specialNotes}}
 
 يرجى تأكيد الحضور بالإجابة بـِ "نعم" أو "لا".
 إذا كنتم تحتاجون لمترجم، يرجى الرّد بكلمة "مترجم".
 إذا كانت لديكم أيّة استفسارات، يرجى الاتّصال بعيادة السانكتشوري (الدكتور مايكل ستيفنسن) على الرّقم التّالي: \u200E226-336-1321`,
 
-    Amharic: `ለ {{{patientName}}}፣ ይህ መልእክት የሚከተለው ቀጠሮ እንዳለዎት ለማሳወቅ ነው፥:{{{#description}}}
-{{{description}}}{{{/description}}}
+    Amharic: `ለ {{{patientName}}}፣ ይህ መልእክት የሚከተለው ቀጠሮ እንዳለዎት ለማሳወቅ ነው፥:{{#description}}
+{{{description}}}{{/description}}
 ቀን፦ {{{appointmentDate}}}
 ሰዐት፦ {{{appointmentTime}}}
-አድራሻ፦ {{{practitionerAddress}}}{{{#specialNotes}}}
-ማስታወሻ፦ {{{specialNotes}}}{{{/specialNotes}}}
+አድራሻ፦ {{{practitionerAddress}}}{{#specialNotes}}
+ማስታወሻ፦ {{{specialNotes}}}{{/specialNotes}}
 
 በዚህ ቀጠሮ ላይ እገኛለሁ ወይም አልገኝም በማለት እንዲያሳውቁን በትህትና እንጠይቃለን።
 አስተርጓሚ ካስፈለግዎ፣ እባኮ "አስተርጓሚ" በማለት ይመልሱ።
 ጥያቄ ካለዎት፣እባኮ በ 226-336-1321 Sanctuary Refugee Health Centre በመደወል (ዶ/ር ማይክል
 ስቴፈንሰን) ያነጋግሩ። `,
 
-    Somali: `Gacaliye {{{patientName}}}, Farriintan ayaa ah in lagu ogeysiiyo ballantaada soo socota:{{{#description}}}
-{{{description}}}{{{/description}}}
+    Somali: `Gacaliye {{{patientName}}}, Farriintan ayaa ah in lagu ogeysiiyo ballantaada soo socota:{{#description}}
+{{{description}}}{{/description}}
 Taariikh: {{{appointmentDate}}}
 Waqtiga: {{{appointmentTime}}}
-Cinwaanka: {{{practitionerAddress}}}{{{#specialNotes}}}
-Ogeysiis gaar ah: {{{specialNotes}}}{{{/specialNotes}}}
+Cinwaanka: {{{practitionerAddress}}}{{#specialNotes}}
+Ogeysiis gaar ah: {{{specialNotes}}}{{/specialNotes}}
 
 Fadlan xaqiiji imaanshahaaga adoo ku jawaabaya "Haa" ama "Maya"
 Haddii aad u baahan tahay turjubaan, fadlan ku jawaab ereyga "turjubaan"
 Haddii aad wax su'aalo ah qabtid, fadlan wac Xarunta Caafimaadka Qaxootiga ee Sanctuary (Dr. Michael Stephenson) lambarka 226-336-1321`,
 
-    Turkish: `Sayin {{{patientName}}}, Bu mesaj randevunuz ile ilgili sizi bilgilendirme amacli gonderilmistir:{{{#description}}}
-{{{description}}}{{{/description}}}
+    Turkish: `Sayin {{{patientName}}}, Bu mesaj randevunuz ile ilgili sizi bilgilendirme amacli gonderilmistir:{{#description}}
+{{{description}}}{{/description}}
 Tarih: {{{appointmentDate}}}
 Saat: {{{appointmentTime}}}
-Adres: {{{practitionerAddress}}}{{{#specialNotes}}}
-Ozel notlar: {{{specialNotes}}}{{{/specialNotes}}}
+Adres: {{{practitionerAddress}}}{{#specialNotes}}
+Ozel notlar: {{{specialNotes}}}{{/specialNotes}}
 
 Lutfen randevunuza katilim durumunuzu, bu mesaji “Evet” ya da “Hayir” seklinde
 yanitlayarak bildiriniz
@@ -63,23 +63,23 @@ Eger tercumana ihtiyaciniz varsa lutfen bu mesaji "tercuman" yazarak yanitlayini
 Sorulariniz icin lutfen bizi 226-336-1321 numarali telefondan arayiniz.
 Sanctuary Refugee Health Centre - Dr Michael Stephenson`,
 
-    Spanish: `Estimado(a) {{{patientName}}}, Este mensaje es para informarle que usted tiene una próxima cita:{{{#description}}}
-{{{description}}}{{{/description}}}
+    Spanish: `Estimado(a) {{{patientName}}}, Este mensaje es para informarle que usted tiene una próxima cita:{{#description}}
+{{{description}}}{{/description}}
 Fecha: {{{appointmentDate}}}
 Hora: {{{appointmentTime}}}
-Direccion: {{{practitionerAddress}}}{{{#specialNotes}}}
-Notas especiales: {{{specialNotes}}}{{{/specialNotes}}}
+Direccion: {{{practitionerAddress}}}{{#specialNotes}}
+Notas especiales: {{{specialNotes}}}{{/specialNotes}}
 
 Por favor confirme su asistencia respondiendo “Si” o “No”
 Si usted necesita un intérprete, por favor responda con la palabra “intérprete”
 Si usted tiene alguna pregunta, por favor llame a Sanctuary Refugee Health Centre (Dr. Michael Stephenson) al 226-336-1321.`,
 
-    Tigrinya: `ዝኸበርካ/ኪ {{{patientName}}} እዚ ሓበሬታዚ፡ ናይ ዝመጽእ ቆጸራኻ/ኺ መዘኻኸሪ እዩ :{{{#description}}}
-{{{description}}}{{{/description}}}
+    Tigrinya: `ዝኸበርካ/ኪ {{{patientName}}} እዚ ሓበሬታዚ፡ ናይ ዝመጽእ ቆጸራኻ/ኺ መዘኻኸሪ እዩ :{{#description}}
+{{{description}}}{{/description}}
 ዕለት {{{appointmentDate}}}
 ሰዓት {{{appointmentTime}}}
-ኣድራሻ {{{practitionerAddress}}}{{{#specialNotes}}}
-ፍሉይ ሓበሬታ {{{specialNotes}}}{{{/specialNotes}}}
+ኣድራሻ {{{practitionerAddress}}}{{#specialNotes}}
+ፍሉይ ሓበሬታ {{{specialNotes}}}{{/specialNotes}}
 
 ኣብ ቆጸራኻ/ኺ ከም እትርከብ/ቢ፡ ሓብሩና “እወ ክርከብ እየ”፤ “ኣይፋለይን”
 ኣተርጓሚ ዘድልየካ/ኪ እንተኾይኑ፡ “ኣተርጓሚ” ( interpreter ) የድልየኒ እዩ ብምባል መልሱልና ።
@@ -121,69 +121,69 @@ Si usted tiene alguna pregunta, por favor llame a Sanctuary Refugee Health Centr
   {
     templateId: 3,
     templateName: "Appointment Reminder Subsequent",
-    English: `Dear {{{patientName}}}, this message is to inform you of your upcoming appointment:{{{#description}}}
-{{{description}}}{{{/description}}}
+    English: `Dear {{{patientName}}}, this message is to inform you of your upcoming appointment:{{#description}}
+{{{description}}}{{/description}}
 Date: {{{appointmentDate}}}
 Time: {{{appointmentTime}}}
-Address: {{{practitionerAddress}}}{{{#specialNotes}}}
-Special Notes: {{{specialNotes}}}{{{/specialNotes}}}
+Address: {{{practitionerAddress}}}{{#specialNotes}}
+Special Notes: {{{specialNotes}}}{{/specialNotes}}
 
 If you have any questions, please call Sanctuary Refugee Health Centre (Dr. Michael Stephenson) at 226-336-1321.`,
 
     // \u200E is the left-to-right mark and is used to improve mixing LTR text into the RTL message
-    Arabic: `السّيد(ة) \u200E{{{patientName}}}، هذه رسالة لإعلامك بالموعد:{{{#description}}}
-\u200E{{{description}}}{{{/description}}}
+    Arabic: `السّيد(ة) \u200E{{{patientName}}}، هذه رسالة لإعلامك بالموعد:{{#description}}
+\u200E{{{description}}}{{/description}}
 التّاريخ: \u200E{{{appointmentDate}}}
 الوقت: \u200E{{{appointmentTime}}}
-العنوان: \u200E{{{practitionerAddress}}}{{{#specialNotes}}}
-تعليمات خاصّة: \u200E{{{specialNotes}}}{{{/specialNotes}}}
+العنوان: \u200E{{{practitionerAddress}}}{{#specialNotes}}
+تعليمات خاصّة: \u200E{{{specialNotes}}}{{/specialNotes}}
 
 إذا كانت لديكم أيّة استفسارات، يرجى الاتّصال بعيادة السانكتشوري (الدكتور مايكل ستيفنسن) على الرّقم التّالي: \u200E226-336-1321`,
 
-    Amharic: `ለ {{{patientName}}}፣ ይህ መልእክት የሚከተለው ቀጠሮ እንዳለዎት ለማሳወቅ ነው፥:{{{#description}}}
-{{{description}}}{{{/description}}}
+    Amharic: `ለ {{{patientName}}}፣ ይህ መልእክት የሚከተለው ቀጠሮ እንዳለዎት ለማሳወቅ ነው፥:{{#description}}
+{{{description}}}{{/description}}
 ቀን፦ {{{appointmentDate}}}
 ሰዐት፦ {{{appointmentTime}}}
-አድራሻ፦ {{{practitionerAddress}}}{{{#specialNotes}}}
-ማስታወሻ፦ {{{specialNotes}}}{{{/specialNotes}}}
+አድራሻ፦ {{{practitionerAddress}}}{{#specialNotes}}
+ማስታወሻ፦ {{{specialNotes}}}{{/specialNotes}}
 
 ጥያቄ ካለዎት፣እባኮ በ 226-336-1321 Sanctuary Refugee Health Centre በመደወል (ዶ/ር ማይክል
 ስቴፈንሰን) ያነጋግሩ። `,
 
-    Somali: `Gacaliye {{{patientName}}}, Farriintan ayaa ah in lagu ogeysiiyo ballantaada soo socota:{{{#description}}}
-{{{description}}}{{{/description}}}
+    Somali: `Gacaliye {{{patientName}}}, Farriintan ayaa ah in lagu ogeysiiyo ballantaada soo socota:{{#description}}
+{{{description}}}{{/description}}
 Taariikh: {{{appointmentDate}}}
 Waqtiga: {{{appointmentTime}}}
-Cinwaanka: {{{practitionerAddress}}}{{{#specialNotes}}}
-Ogeysiis gaar ah: {{{specialNotes}}}{{{/specialNotes}}}
+Cinwaanka: {{{practitionerAddress}}}{{#specialNotes}}
+Ogeysiis gaar ah: {{{specialNotes}}}{{/specialNotes}}
 
 Haddii aad wax su'aalo ah qabtid, fadlan wac Xarunta Caafimaadka Qaxootiga ee Sanctuary (Dr. Michael Stephenson) lambarka 226-336-1321`,
 
-    Turkish: `Sayin {{{patientName}}}, Bu mesaj randevunuz ile ilgili sizi bilgilendirme amacli gonderilmistir:{{{#description}}}
-{{{description}}}{{{/description}}}
+    Turkish: `Sayin {{{patientName}}}, Bu mesaj randevunuz ile ilgili sizi bilgilendirme amacli gonderilmistir:{{#description}}
+{{{description}}}{{/description}}
 Tarih: {{{appointmentDate}}}
 Saat: {{{appointmentTime}}}
-Adres: {{{practitionerAddress}}}{{{#specialNotes}}}
-Ozel notlar: {{{specialNotes}}}{{{/specialNotes}}}
+Adres: {{{practitionerAddress}}}{{#specialNotes}}
+Ozel notlar: {{{specialNotes}}}{{/specialNotes}}
 
 Sorulariniz icin lutfen bizi 226-336-1321 numarali telefondan arayiniz.
 Sanctuary Refugee Health Centre - Dr Michael Stephenson`,
 
-    Spanish: `Estimado(a) {{{patientName}}}, Este mensaje es para informarle que usted tiene una próxima cita:{{{#description}}}
-{{{description}}}{{{/description}}}
+    Spanish: `Estimado(a) {{{patientName}}}, Este mensaje es para informarle que usted tiene una próxima cita:{{#description}}
+{{{description}}}{{/description}}
 Fecha: {{{appointmentDate}}}
 Hora: {{{appointmentTime}}}
-Direccion: {{{practitionerAddress}}}{{{#specialNotes}}}
-Notas especiales: {{{specialNotes}}}{{{/specialNotes}}}
+Direccion: {{{practitionerAddress}}}{{#specialNotes}}
+Notas especiales: {{{specialNotes}}}{{/specialNotes}}
 
 Si usted tiene alguna pregunta, por favor llame a Sanctuary Refugee Health Centre (Dr. Michael Stephenson) al 226-336-1321.`,
 
-    Tigrinya: `ዝኸበርካ/ኪ {{{patientName}}} እዚ ሓበሬታዚ፡ ናይ ዝመጽእ ቆጸራኻ/ኺ መዘኻኸሪ እዩ :{{{#description}}}
-{{{description}}}{{{/description}}}
+    Tigrinya: `ዝኸበርካ/ኪ {{{patientName}}} እዚ ሓበሬታዚ፡ ናይ ዝመጽእ ቆጸራኻ/ኺ መዘኻኸሪ እዩ :{{#description}}
+{{{description}}}{{/description}}
 ዕለት {{{appointmentDate}}}
 ሰዓት {{{appointmentTime}}}
-ኣድራሻ {{{practitionerAddress}}}{{{#specialNotes}}}
-ፍሉይ ሓበሬታ {{{specialNotes}}}{{{/specialNotes}}}
+ኣድራሻ {{{practitionerAddress}}}{{#specialNotes}}
+ፍሉይ ሓበሬታ {{{specialNotes}}}{{/specialNotes}}
 
 ሕቶ እንተለኩም፡ ወይ ዝያዳ ሓበሬታ እንተደለኹም፡ ንሳንክቿሪ ረፉጂ ሀልዝ ሰንተር (Sanctuary Refugee Health Centre, Dr. Michael Stephenson )፡ ንዶር. ማይክል ስቲፈንሰን ኣብ 226-336-132 ብምድዋል ክትሓቱ ትኽእሉ።`,
   },


### PR DESCRIPTION
When using double curly brackets (`{{token}}`) Moustache will apply [percent encoding](https://en.wikipedia.org/wiki/Percent-encoding) to RFC 3986 reserved characters. By switching to triple curly brackets (`{{{token}}}`) Moustache will not do the escaping.

Closes #74 