### PR TITLE
Use language from most recently created appointment when replying

### DIFF
--- a/src/api/handlers/twilio/postReply.js
+++ b/src/api/handlers/twilio/postReply.js
@@ -59,7 +59,10 @@ export async function handlePostReply(patientPhoneNumber, messageFromPatient) {
 
   let appointments;
   try {
-    appointments = await getAppointments(patientPhoneNumber);
+    appointments = await getAppointments(patientPhoneNumber).orderBy(
+      "appointmentId",
+      "desc"
+    );
   } catch (error) {
     console.log(`Could not get appointment for ${patientPhoneNumber}`, error);
     // Can't store reply without appointmentId
@@ -129,8 +132,10 @@ export async function handlePostReply(patientPhoneNumber, messageFromPatient) {
 
   await trx.commit();
 
+  const mostRecentPatientLanguage = appointments[0].language;
+
   const replyText = TemplatesModel.generateReply(
-    appointments[0].language,
+    mostRecentPatientLanguage,
     convertReply(convertedReply)
   );
 

--- a/src/api/handlers/twilio/postReply.test.js
+++ b/src/api/handlers/twilio/postReply.test.js
@@ -14,8 +14,27 @@ describe("Sending A Reply", function () {
     sinon.stub(tClient, "getMessageResponse").callsFake((message) => {
       return message;
     });
-    sinon.stub(appointments, "getAppointments").callsFake(() => {
-      return [{ language: "English" }];
+    sinon.stub(appointments, "getAppointments").callsFake((phoneNumber) => {
+      return {
+        orderBy: async (sortBy, order) => {
+          console.log("asfd");
+          return [
+            { appointmentId: 1, phoneNumber: "123", language: "Turkish" },
+            { appointmentId: 2, phoneNumber: "123", language: "English" },
+            { appointmentId: 3, phoneNumber: "321", language: "English" },
+            { appointmentId: 4, phoneNumber: "321", language: "Turkish" },
+          ]
+            .filter((item) => {
+              return item.phoneNumber === phoneNumber;
+            })
+            .sort((a, b) => {
+              if (order === "desc") {
+                return a[sortBy] < b[sortBy] ? 1 : -1;
+              }
+              return a[sortBy] > b[sortBy] ? 1 : -1;
+            });
+        },
+      };
     });
     sinon.stub(communications, "insertReply").callsFake(() => {
       return true;
@@ -29,6 +48,13 @@ describe("Sending A Reply", function () {
     assert.equal(
       await postReplyFunctions.handlePostReply("123", "yes"),
       "Thank you!"
+    );
+  });
+
+  it("Response with Turkish when they say yes", async function () {
+    assert.equal(
+      await postReplyFunctions.handlePostReply("321", "yes"),
+      "Teşekkür ederim!"
     );
   });
 


### PR DESCRIPTION
This is to fix the issue found by Eda:

![eda](https://user-images.githubusercontent.com/5401207/100645122-265ee000-3334-11eb-99ef-dde87e1ec8fe.png)

The issue is caused when a patient has appointments in more than one language. Which language used for the reply text is currently non-deterministic. This changes it so that the language of the most recently created appointment is used.